### PR TITLE
Return early when metaKey is pressed

### DIFF
--- a/application.js
+++ b/application.js
@@ -15,7 +15,7 @@ window.Application = class Application {
   }
 
   handleKeyboardEvent (e) {
-    if (e.ctrlKey || this.insideInput(e)) {
+    if (e.ctrlKey || e.metaKey || this.insideInput(e)) {
       return
     }
 


### PR DESCRIPTION
This prevents this extension from firing when intentionally using the
browsers search.